### PR TITLE
Remove locked state for RTE token

### DIFF
--- a/erc20/0x436F0F3a982074c4a05084485D421466a994FE53.json
+++ b/erc20/0x436F0F3a982074c4a05084485D421466a994FE53.json
@@ -7,7 +7,6 @@
     "email": "official@rate3.network",
     "website": "https://rate3.network",
     "whitepaper": "https://uploads-ssl.webflow.com/5a7d218d6001ff0001f3d5cc/5afc0d84ab090f5b58d9a7ec_Rate3%20Whitepaper__v2.2.pdf",
-    "state": "LOCKED",
     "published_on": "2018-04-09",
     "initial_price": {
         "ETH": "0.0000625 ETH"


### PR DESCRIPTION
RTE tokens are now unlocked and ERC20 functionality restored.