### PR TITLE
VEMC

### DIFF
--- a/erc20/0xCC55cf17d21c758E52b87113a7143116e4d9EB10.json
+++ b/erc20/0xCC55cf17d21c758E52b87113a7143116e4d9EB10.json
@@ -1,5 +1,5 @@
 {
-  "symbol": "VMC",
+  "symbol": "VMC(IOT)",
   "address": "0xCC55cf17d21c758E52b87113a7143116e4d9EB10",
   "overview":{
         "en": "Vending Machine Chain (VMC) , is the world's first commercialized public chain for unmanned vending equipment, combining IoT technology and blockchain technology to create a blockchain + unmanned new retail solution.",

--- a/erc20/0xCC55cf17d21c758E52b87113a7143116e4d9EB10.json
+++ b/erc20/0xCC55cf17d21c758E52b87113a7143116e4d9EB10.json
@@ -1,8 +1,8 @@
 {
-  "symbol": "VMC(IOT)",
+  "symbol": "VEMC",
   "address": "0xCC55cf17d21c758E52b87113a7143116e4d9EB10",
   "overview":{
-        "en": "Vending Machine Chain (VMC) , is the world's first commercialized public chain for unmanned vending equipment, combining IoT technology and blockchain technology to create a blockchain + unmanned new retail solution.",
+        "en": "Vending Machine Chain (VEMC) , is the world's first commercialized public chain for unmanned vending equipment, combining IoT technology and blockchain technology to create a blockchain + unmanned new retail solution.",
         "zh": "新零链（Vending Machine Chain），是全球首个针对无人自动售卖设备的商业化公有链，结合物联网技术与区块链技术，打造区块链+无人新零售解决方案。"
   },
   "email": "vmc@vem.im",


### PR DESCRIPTION
因VMC名称已有重复名称的代币，为了更好的诠释贴合项目，以及VEM是Vending Machine简写，所以将名称由 VMC 更改至 VEMC。
原VMC已提交改为VMC_Old：[https://github.com/consenlabs/token-profile/pull/1111](https://github.com/consenlabs/token-profile/pull/1111)