### PR TITLE
VMC更名为VEMC

### DIFF
--- a/erc20/0xCC55cf17d21c758E52b87113a7143116e4d9EB10.json
+++ b/erc20/0xCC55cf17d21c758E52b87113a7143116e4d9EB10.json
@@ -1,5 +1,5 @@
 {
-  "symbol": "VMC",
+  "symbol": "VMC(IOT)",
   "address": "0xCC55cf17d21c758E52b87113a7143116e4d9EB10",
   "overview":{
         "en": "Vending Machine Chain (VMC) , is the world's first commercialized public chain for unmanned vending equipment, combining IoT technology and blockchain technology to create a blockchain + unmanned new retail solution.",

--- a/erc20/0xCC55cf17d21c758E52b87113a7143116e4d9EB10.json
+++ b/erc20/0xCC55cf17d21c758E52b87113a7143116e4d9EB10.json
@@ -2,7 +2,7 @@
   "symbol": "VEMC",
   "address": "0xCC55cf17d21c758E52b87113a7143116e4d9EB10",
   "overview":{
-        "en": "Vending Machine Chain (VEMC) , is the world's first commercialized public chain for unmanned vending equipment, combining IoT technology and blockchain technology to create a blockchain + unmanned new retail solution.",
+        "en": "Vending Machine Chain (VEMC), is the world's first commercialized public chain for unmanned vending equipment, combining IoT technology and blockchain technology to create a blockchain + unmanned new retail solution.",
         "zh": "新零链（Vending Machine Chain），是全球首个针对无人自动售卖设备的商业化公有链，结合物联网技术与区块链技术，打造区块链+无人新零售解决方案。"
   },
   "email": "vmc@vem.im",
@@ -11,5 +11,8 @@
   "published_on": "2018-07-04",
   "initial_price":{
         "ETH":"0.0000125 ETH"
+  },
+  "links": {
+    "twitter": "https://twitter.com/VEM_Chain"
   }
 }

--- a/erc20/0xCC55cf17d21c758E52b87113a7143116e4d9EB10.json
+++ b/erc20/0xCC55cf17d21c758E52b87113a7143116e4d9EB10.json
@@ -1,8 +1,8 @@
 {
-  "symbol": "VMC(IOT)",
+  "symbol": "VEMC",
   "address": "0xCC55cf17d21c758E52b87113a7143116e4d9EB10",
   "overview":{
-        "en": "Vending Machine Chain (VMC) , is the world's first commercialized public chain for unmanned vending equipment, combining IoT technology and blockchain technology to create a blockchain + unmanned new retail solution.",
+        "en": "Vending Machine Chain (VEMC) , is the world's first commercialized public chain for unmanned vending equipment, combining IoT technology and blockchain technology to create a blockchain + unmanned new retail solution.",
         "zh": "新零链（Vending Machine Chain），是全球首个针对无人自动售卖设备的商业化公有链，结合物联网技术与区块链技术，打造区块链+无人新零售解决方案。"
   },
   "email": "vmc@vem.im",


### PR DESCRIPTION
为了更好的体现代表的行业区块链，需要修改币名，已发布声明：[https://twitter.com/VEM_Chain/status/1021710258664660992](https://twitter.com/VEM_Chain/status/1021710258664660992)
旧币名VMC已提交改为VMC_Old([https://github.com/consenlabs/token-profile/pull/1344](https://github.com/consenlabs/token-profile/pull/1344)
关于合约地址未变动的原因，将通过 vmc@vem.im 邮箱发送说明邮件给 support@consenlabs.com 进行说明。