### PR TITLE
Game Cell Coin 名称显示

### DIFF
--- a/erc20/0x500565e098d98a273224ec8fb33d98dc8946f8b9.json
+++ b/erc20/0x500565e098d98a273224ec8fb33d98dc8946f8b9.json
@@ -1,9 +1,9 @@
 {
   "symbol": "GCC",
-  "address": "0x500565E098d98A273224eC8Fb33d98dC8946F8B9",
+  "address": "0x500565e098d98a273224ec8fb33d98dc8946f8b9",
   "overview":{
         "en": "GameCell is Ecological Game Community Based on Blockchain.",
-        "zh": "GameCell(游戏星球)是全方位的区块链游戏聚合平台。"
+        "zh": "GameCell 游戏星球是全方位的区块链游戏聚合平台。"
   },
   "email": "gamecell.foundation@gmail.com",
   "website": "http://www.gamecell.io/",


### PR DESCRIPTION
你好，我们是gamecell团队我们的token名称是GCC
合约地址为0x500565e098d98a273224ec8fb33d98dc8946f8b9
相关报道:金色财经-https://m.jinse.com/bitcoin/219320.html
这是我们第二次更新

imtoken1.0的问题：
代币在钱包中显示为GCC16,多出了数字16,给我们的用户带来了很大困扰，请尽快帮我们解决，非常感谢
麻烦请将代币名称显示为GCC