### PR TITLE
Modified README.zh-CN.md

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,7 +25,7 @@ git clone git@github.com:xxxxxxxx/token-profile.git
 4. 在 erc20 目录里添加一个新的 json 文件，使用 **checksum** 代币合约地址命名这个 json 文件。举例：
 *0xf90f1648926005A8bb3ed8ec883164De7F768743.json*
 
-5. json 文件的内容参照模板文件：[$template.json](./erc20/$template.json)
+5. json 文件请使用UTF-8编码，否则Travis-CI会构建失败。内容请参照模板文件：[$template.json](./erc20/$template.json)
 6. 代币 logo 放到 images 目录里，图片名称也是使用 **checksum** 代币合约地址命名。对于 logo 的要求参照下面的说明
 7. 如果你的代币已经被添加了，你可以在对应的目录下更新相应的代币信息
 8. commit 提交信息


### PR DESCRIPTION
> /erc20/$template.json should be encoded as UTF-8 , otherwise Travis-CI will build failed.

**$template.json**这个文件默认不是UTF-8编码的，导致很多内容含有中文的合并请求在Travis-CI构建测试的时候失败了，请开发者大大在说明文件中做特别提示，谢谢！