### PR TITLE
GCC_Old

### DIFF
--- a/erc20/0x500565E098d98A273224eC8Fb33d98dC8946F8B9.json
+++ b/erc20/0x500565E098d98A273224eC8Fb33d98dC8946F8B9.json
@@ -1,5 +1,5 @@
 {
-  "symbol": "GCC",
+  "symbol": "GCC_Old",
   "address": "0x500565E098d98A273224eC8Fb33d98dC8946F8B9",
   "overview":{
         "en": "GameCell is Ecological Game Community Based on Blockchain.",


### PR DESCRIPTION
GCC_Old 声明:http://gamecell.io/res/GameCellNotice_EN.pdf

能否将我们的GCC地址0x8BcB64bfDA77905398b67aF0Af084c744e777A20在1.0版本的钱包里代币名称显示成GCC(GameCell)么，重名的太多，谢谢