### PR TITLE
代币显示错误。

### DIFF
--- a/erc20/0x5581c0bc21a762e43d148b06d310f088b6cf97b3.json
+++ b/erc20/0x5581c0bc21a762e43d148b06d310f088b6cf97b3.json
@@ -1,4 +1,5 @@
-{
+﻿{
+  "symbol": "SE(SwiftExpress)",
   "symbol": "SE",
   "address": "0x5581c0bc21a762e43d148b06d310f088b6cf97b3",
   "overview":{

--- a/erc20/0x5581c0bc21a762e43d148b06d310f088b6cf97b3.json
+++ b/erc20/0x5581c0bc21a762e43d148b06d310f088b6cf97b3.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "symbol": "SE(SwiftExpress)",
   "symbol": "SE",
   "address": "0x5581c0bc21a762e43d148b06d310f088b6cf97b3",


### PR DESCRIPTION
管理员你好，SE名称在imtoken1.0显示错误，请求管理员修改。
imtoken1.0显示为SE(SwiftExpress)，实际应该显示为：SE，请求管理员修改。
我们是旧合约更替，旧合约已经更替了old名称。而新合约显示错误。
https://github.com/consenlabs/token-profile/pull/2487#issuecomment-423478372