### PR TITLE
ifx小写改大写 IFX

### DIFF
--- a/erc20/0x68dE11BC4B2623E352E92aDf0a2DaDB0dA9A18af.json
+++ b/erc20/0x68dE11BC4B2623E352E92aDf0a2DaDB0dA9A18af.json
@@ -1,5 +1,5 @@
 {
-  "symbol": "ifx",
+  "symbol": "IFX",
   "address": "0x68dE11BC4B2623E352E92aDf0a2DaDB0dA9A18af",
   "overview":{
         "en": "IFX.DO is committed to building the world's biggest one-stop online risk trading service platform integrating deep social communication, trading competition & one-click strategy-following, crowdfunding asset management and AI fund. The exclusive automatic risk control competition and strategy output system developed by ifx.do will effectively realize the intelligent interaction and value transmission.",


### PR DESCRIPTION
团队背景：ifx创始团队来自金融、互联网自身从业者有超过十年得从业经，并成功创办外汇垂直社交媒体，技术团队均拥有金融+IT的跨界经验，致力于打造全球领先的衍生品交易竞技平台。
项目基本情况：智汇网 (IFX.do) 为新加坡 IFXDO Pte. Ltd.下属科技公司，致力于为全球在线风险交易者提供交易竞技+操作分享服务，第一期版本支持外汇、贵金属、原油、数字货币交易。目前该项目为区块链交易社区中完全落地的项目，点击 www.ifx.do 即可访问并使用所有网站功能。 智汇网在线交易系统内置风控规则，参加竞技的操盘手必须在严格的风控框架下进行竞技，从根本上杜绝了操盘手的重仓、漂单、情绪化交易。同时，智汇网利用区块链分布式记账技术将竞技数据上链，保证了比赛的真实性和公平性。 另外，智汇网还可以让观赛用户把优秀操盘手的策略一键复制到自己的实盘，目前已经支持全球上千家外汇、贵金属、原油.交易商。
更多关于 ifx 的信息
官网：https://www.ifx.do
微博：https://weibo.com/u/6791622085
### 媒体报道：
微信：https://mp.weixin.qq.com/s/y181uza4BDIg0U_70zf6EQ
微信：https://mp.weixin.qq.com/s/ajDSg7d76w9TRCrUJxKZdQ
搜狐：http://www.sohu.com/a/288817183_100280495
太平洋财富网 ：http://www.pcfortune.com.cn/news/pic/2019/0114/pic10513.html
华尔街财经网 ：http://www.xy178.com/gs/2019/0114/gs120246974.html
新讯网 ：http://news.xinxunwang.com/world/gdyw/208940.html
龙讯财经 ：https://www.longau.com/article/2019-1-14/1547436997099.html
天极网 ： http://news.yesky.com/hotnews/406/2143479906.shtml
极客网 ： http://www.fromgeek.com/vendor/218651.html
### 收录的交易所：https://hk.coineal.com/
### 转账所需 Gas Limit：60000