### PR TITLE
TrueUSD To TUSD

### DIFF
--- a/erc20/0x0000000000085d4780B73119b644AE5ecd22b376.json
+++ b/erc20/0x0000000000085d4780B73119b644AE5ecd22b376.json
@@ -1,5 +1,5 @@
 {
-    "symbol": "TrueUSD",
+    "symbol": "TUSD",
     "address": "0x0000000000085d4780B73119b644AE5ecd22b376",
     "overview": {
         "en": "TrueUSD (TUSD) is the first independently-verified digital asset fully collateralized by US Dollars. The ERC20 stablecoin uses multiple escrow accounts to reduce counterparty risk, provide transparent attestations, and legal protections against fraud. TUSD users enjoy the lowest gas costs of any stablecoin thanks to GasBoost; easy wallet alias creation through Autosweep; and direct-to-bank TUSD transactions through unique, easy-to-remember Redemption Addresses.",

--- a/erc20/0x00000000441378008EA67F4284A57932B1c000a5.json
+++ b/erc20/0x00000000441378008EA67F4284A57932B1c000a5.json
@@ -1,5 +1,5 @@
 {
-    "symbol": "TrueGBP",
+    "symbol": "TGBP",
     "address": "0x00000000441378008EA67F4284A57932B1c000a5",
     "overview": {
         "en": "TrueGBP (TGBP) is an independently-verified digital asset fully collateralized by pounds sterling. The ERC20 stablecoin provides transparent attestations and legal protections against fraud. TGBP users enjoy the lowest gas costs of any stablecoin thanks to GasBoost; easy wallet alias creation through Autosweep; and direct-to-bank TGBP transactions through unique, easy-to-remember Redeption Addresses.",

--- a/erc20/0x00000100F2A2bd000715001920eB70D229700085.json
+++ b/erc20/0x00000100F2A2bd000715001920eB70D229700085.json
@@ -1,5 +1,5 @@
 {
-    "symbol": "TrueCAD",
+    "symbol": "TCAD",
     "address": "0x00000100F2A2bd000715001920eB70D229700085",
     "overview": {
         "en": "TrueCAD (TCAD) is an independently-verified digital asset fully collateralized by Canadian dollars. The ERC20 stablecoin provides transparent attestations and legal protections against fraud. TCAD users enjoy the lowest gas costs of any stablecoin thanks to GasBoost; easy wallet alias creation through Autosweep; and direct-to-bank TCAD transactions through unique, easy-to-remember Redeption Addresses.",

--- a/erc20/0x00006100F7090010005F1bd7aE6122c3C2CF0090.json
+++ b/erc20/0x00006100F7090010005F1bd7aE6122c3C2CF0090.json
@@ -1,5 +1,5 @@
 {
-    "symbol": "TrueAUD",
+    "symbol": "TAUD",
     "address": "0x00006100F7090010005F1bd7aE6122c3C2CF0090",
     "overview": {
         "en": "TrueAUD (TAUD) is an independently-verified digital asset fully collateralized by Australian dollars. The ERC20 stablecoin provides transparent attestations and legal protections against fraud. TAUD users enjoy the lowest gas costs of any stablecoin thanks to GasBoost; easy wallet alias creation through Autosweep; and direct-to-bank TAUD transactions through unique, easy-to-remember Redeption Addresses.",

--- a/erc20/0x0000852600CEB001E08e00bC008be620d60031F2.json
+++ b/erc20/0x0000852600CEB001E08e00bC008be620d60031F2.json
@@ -1,5 +1,5 @@
 {
-    "symbol": "TrueHKD",
+    "symbol": "THKD",
     "address": "0x0000852600CEB001E08e00bC008be620d60031F2",
     "overview": {
         "en": "TrueHKD (THKD) is an independently-verified digital asset fully collateralized by Hong Kong dollars. The ERC20 stablecoin provides transparent attestations and legal protections against fraud. THKD users enjoy the lowest gas costs of any stablecoin thanks to GasBoost; easy wallet alias creation through Autosweep; and direct-to-bank THKD transactions through unique, easy-to-remember Redeption Addresses.",


### PR DESCRIPTION

#### Changes
这将纠正TrueCurrencies的符号，例如TUSD。
This corrects the symbol for the TrueCurrencies such as TUSD.
This mistake was made in https://github.com/consenlabs/token-profile/pull/4842 although for TUSD it seems to have happened beforehand.
Reviewers @sfsy520