### PR TITLE
Update FF token

### DIFF
--- a/erc20/0xC86D4914F3E162dc44A7dDd2326102E75FA1B0d1.json
+++ b/erc20/0xC86D4914F3E162dc44A7dDd2326102E75FA1B0d1.json
@@ -1,6 +1,6 @@
 {
 	"symbol": "FF",
-    "address": "0xC86D4914F3E162dc44A7dDd2326102E75FA1B0d1",
+    "address": "0x4ce0054AeE52d70A1C452266Bd6523D1EC7C99E6",
     "overview": {
         "en": "Faraday Future is a token issued by the Faraday Exchange,Faraday Exchange is a community autonomous digital asset trading platform dedicated to quality project issuance.",
         "zh": "FaradayFuture是法拉第交易所发行的代币，简称FF.法拉第（FFex.pro）交易所是一个致力于优质项目发行的社区自治型数字资产交易平台。旗下拥有项目链改平台中国直通硅谷（Chinasv.com）、CityChainDapp（ocity.io）、区块链游戏平台乐手游（6shouyou.com）、区块链社区CITY中国和全球城市节点，是区块链行业唯一的场景落地生态收益+交易所平台币权益+社区自治共振价值三合一的数字资产交易平台。"


### PR DESCRIPTION
您好：
    把原有的FF代币信息（对应pr 5050）中的合约地址0xC86D4914F3E162dc44A7dDd2326102E75FA1B0d1替换成最新的合约地址0x4ce0054AeE52d70A1C452266Bd6523D1EC7C99E6




官方公告：
    法拉第平台币FF手续费每周销毁（第一期）销毁公示 https://www.ffex.pro/noticeInfo/3436


团队背景：
    法拉第团队分布在新加坡、北京和天津，核心成员有超过11 年互联网产品及运营经验。刘杰，2017年创办City Dapp，经过短短1年内的发展，City Dapp已拥有147万KYC，2.6万的付费持币用户。2019年，在CITY中国社区基础上发起法拉第（FFex）交易所。


项目基本情况：
    法拉第（FFEX）交易所是一个致力于优质项目发行的社区自治型数字资产交易平台。旗下拥有7000+项目链改平台中国直通硅谷（Chinasv.com）、147万KYC用户Dapp（ocity.io）、57万日活用户区块链游戏平台（6shouyou.com）、2万+付费持币用户区块链社区CITY中国和72个城市节点，是区块链行业唯一的场景落地生态收益+交易所平台币权益+社区自治共振价值三合一的数字资产交易平台。
法拉第是全球数字金融服务领导者，以让资产像电一样自由流通为愿景，秉承社区化经营理念，致力于打造全球最大社区自治型数字资产交易平台，践行区块链重构生产关系的终极目标，探索大规模、高效率协作网络的搭建。


媒体报道：
    法拉第 优质项目、增量用户能否引爆交易所平台币潜在价值？ https://www.toutiao.com/i6733381893972034060/


建议 gas limit：100000


收录的交易所：
    法拉第 https://www.ffex.pro/