### PR TITLE
update wuc token profile

### DIFF
--- a/erc20/0x9e9801BACE260f58407C15E6e515C45918756E0F.json
+++ b/erc20/0x9e9801BACE260f58407C15E6e515C45918756E0F.json
@@ -1,6 +1,6 @@
 {
-    "symbol": "WUC",
-    "address": "0x9e9801BACE260f58407C15E6e515C45918756E0F",
-    "website": "https://www.wuccoin.com",
-    "whitepaper": "https://share.weiyun.com/5l6TBdF"
+  "symbol": "WUC",
+  "address": "0x9e9801BACE260f58407C15E6e515C45918756E0F",
+  "website": "http://www.wuccoin.com/",
+  "whitepaper": "http://www.wuccoin.com/images/wp.pdf"
 }


### PR DESCRIPTION
**项目资料：**

官方公告：http://www.wuccoin.com/
团队背景：
世联通证是由联合国协会世界联合会（ WFUNA）与在塞拉利昂共和国注册的几大机构、世联大同基金会、中非投资集团有限公司、中非银行集团有限公司、环球区块链数字货币银行集团有限公司、中非区块应用研究院、中非环球区块链数字货币交易所联合发起，并由世界数字货币金融管理委员会（ GCFMC）监管和指导发行。
 
世联通证以区块链的技术和思维，促进全球发展中国家经济快速发展和财政独立，最终实现建立一个更自由、更平衡和更公平的国际金融体系。
 
项目基本情况：
世联通证（WUC）是世界联合数字资产通证的简称。
通证经济是下一代互联网的数字经济。它立足于实体经济，启发和鼓励公众把各种权益证明全部拿出来通证化，并把通证充分运用起来，放到区块链上流转，放到市场上交易，让市场自动形成价格，在现实经济生活中可以消费、验证等，他是切实可用的东西，因而紧贴实体经济。区块链上的通证比手持的卡、券、积分、票据等的流转速度快几百几千倍，比今天的市场价格信号灵敏和精细几百甚至几千倍，从而把有效市场甚至完美市场推进到每一个徹观领域。将人工智能、通证和区块链三者合起来，已经不是生产和生活方式简单变化的问题，而是人类文明演进和生命存在意义的改变和超越。
世联通证是通证经济的具体实施和运用。它面向全球发展中国家，以具有优势的自然资源价值来直接进行锚定，在区块链平台上发行其主权加密数字资产的通证；是发展中国家国民可以直接参与的独立透明开放的数字金融的先锋，它将成为促进新兴经济体发展，促进自主和贸易公平的金融体系发展的平台。
官网：http://www.wuccoin.com

媒体报道
无

gas limit：60000

收录的交易所
https://www.gexday.com/dealcenter



#### 我方已更新wuc的相关资料 申请去除imtoken上的骷髅头标志