### PR TITLE
AngryB 更換白皮書超鏈接，更換官方twitter

### DIFF
--- a/erc20/0x2c9acEb63181cd08a093d052ec041e191f229692.json
+++ b/erc20/0x2c9acEb63181cd08a093d052ec041e191f229692.json
@@ -7,7 +7,7 @@
     },
     "email": "angryb668888@gmail.com",
     "website": "http://angryb.io/",
-    "whitepaper": "https://raw.githubusercontent.com/angryb888/AngryBbirdpaper/main/ANGRYBAINU_Ecosystem_BIRD_Paper.pdf",
+    "whitepaper": "https://github.com/angryb888/AngryBlockchain/raw/main/AngryBlockchain_Birdpaper_Official.pdf",
     "state": "NORMAL",
     "published_on": "2021-07-17",
     "initial_price": {
@@ -17,10 +17,10 @@
     },
     "links": {
         "blog": "",
-        "twitter": " https://twitter.com/angryb17",
-        "telegram": "https://t.me/AngryBOffical",
+        "twitter": "https://twitter.com/Official_AngryB",
+        "telegram": "https://t.me/angryblockchainofficial1",
         "github": "https://github.com/angryb888/Angry-Token-Profile",
-        "facebook": "https://www.facebook.com/groups/angrybenglishoffical",
+        "facebook": "https://www.facebook.com/OfficialAngryBCommunity",
         "reddit": "https://www.reddit.com/r/AngryB/",
         "slack": "",
         "medium": "https://medium.com/@angryb668888"


### PR DESCRIPTION
项目资料：

團隊背景:Angryb起源於社區共識，由各領域不願具名的深耕者共同協作，其最大願景為保護散戶不再受到庄家的霸凌。
項目基本情況:ANB為憤怒幣，其新創方式為無風險預買以及致敬V神但分77777年給他20%的代幣，避免讓屎幣的悲劇重演。
收錄的交易所:Uniswap(目前)、Binance、Crypto.com、Coinbase(未來)
CoinGecko：
https://www.coingecko.com/zh/%E6%95%B0%E5%AD%97%E8%B4%A7%E5%B8%81/angryb
Feixiaohao：
https://www.feixiaohao.com/currencies/angryb
建議的Gas Limit：60000
關於更多ANB的信息
Angryb 中文FB社群 : https://www.facebook.com/groups/angrybchineseoffical
Angryb English FB : https://www.facebook.com/OfficialAngryBCommunity
Angryb Telegram : https://t.me/angryblockchainofficial1
Angryb Twitter : https://twitter.com/Official_AngryB
Angryb Medium : https://medium.com/@angryb668888
Angryb Discord : https://discord.gg/k5ntnDUw8V
Angryb Reddit : https://www.reddit.com/r/AngryB/